### PR TITLE
aws環境のCI/CDファイル一式追加

### DIFF
--- a/aws/awscli_setup.sh
+++ b/aws/awscli_setup.sh
@@ -1,0 +1,10 @@
+#/bin/sh
+
+apk add aws-cli
+
+mkdir /root/.aws
+cat << 'EOF' > /root/.aws/config
+[default]
+region = ap-northeast-1
+output = json
+EOF

--- a/aws/backend_task.json
+++ b/aws/backend_task.json
@@ -1,0 +1,115 @@
+{
+    "executionRoleArn": "$EXECUTION_ROLE_ARN",
+    "containerDefinitions": [
+        {
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-region": "${REGION}",
+                    "awslogs-group": "/ecs/${PRODUCT_NAME}/backend-task",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "portMappings": [
+                {
+                    "hostPort": 5000,
+                    "protocol": "tcp",
+                    "containerPort": 5000
+                }
+            ],
+            "environment": [
+                {
+                    "name": "XCKAN_ALLOWED_HOSTS",
+                    "value": "*"
+                },
+                {
+                    "name": "XCKAN_SOLR",
+                    "value": "http://localhost:8983/solr/ckan-xsearch"
+                }
+            ],
+            "image": "<IMAGE1_NAME>",
+            "dependsOn": [
+                {
+                    "containerName": "solr",
+                    "condition": "START"
+                }
+            ],
+            "readonlyRootFilesystem": false,
+            "mountPoints": [
+                {
+                    "readOnly": null,
+                    "containerPath": "/ext",
+                    "sourceVolume": "django_volume"
+                }
+            ],
+            "name": "django"
+        },
+        {
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-region": "${REGION}",
+                    "awslogs-group": "/ecs/${PRODUCT_NAME}/backend-task",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            },
+            "entryPoint": null,
+            "portMappings": [
+                {
+                    "hostPort": 8983,
+                    "protocol": "tcp",
+                    "containerPort": 8983
+                }
+            ],
+            "command": [
+                "solr-precreate",
+                "ckan-xsearch"
+            ],
+            "environment": [
+                {
+                    "name": "VERBOSE",
+                    "value": "no"
+                }
+            ],
+            "image": "${INIT_ECR_URL}:${TASK_NAME}-solr-follower-1.0",
+            "essential": true,
+            "readonlyRootFilesystem": false,
+            "name": "solr"
+        }
+    ],
+    "taskRoleArn": "$TASK_ROLE_ARN",
+    "family": "$TASK_NAME",
+    "requiresCompatibilities": [
+        "FARGATE"
+    ],
+    "networkMode": "awsvpc",
+    "memory": "$MEMORY",
+    "cpu": "$CPU",
+    "volumes": [
+        {
+            "name": "django_volume"
+        }
+    ],
+    "tags": [
+        {
+            "key": "Project",
+            "value": "$PROJECT_NAME"
+        },
+        {
+            "key": "Product",
+            "value": "$PRODUCT_NAME"
+        },
+        {
+            "key": "Terraform",
+            "value": "true"
+        },
+        {
+            "key": "Env",
+            "value": "$ENV"
+        },
+        {
+            "key": "Name",
+            "value": "$TASK_NAME"
+        }
+    ]
+}

--- a/aws/create_dockerfile.sh
+++ b/aws/create_dockerfile.sh
@@ -1,0 +1,14 @@
+#/bin/sh
+
+cp -p aws/awscli_setup.sh backend/awscli_setup.sh
+cat << 'EOF' >> backend/Dockerfile
+
+
+# Setup AWS CLI
+COPY awscli_setup.sh /tmp
+RUN chmod +x /tmp/awscli_setup.sh && /tmp/awscli_setup.sh
+ARG XCKAN_SITEMAP_URL
+ARG XCKAN_SITEMAP_DIR
+ENV XCKAN_SITEMAP_URL=${XCKAN_SITEMAP_URL}
+ENV XCKAN_SITEMAP_DIR=${XCKAN_SITEMAP_DIR}
+EOF

--- a/aws/follower_backend_appspec.yml
+++ b/aws/follower_backend_appspec.yml
@@ -1,0 +1,9 @@
+version: 0.0
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: <TASK_DEFINITION>
+        LoadBalancerInfo:
+          ContainerName: "django"
+          ContainerPort: 5000

--- a/aws/follower_backend_buildspec.yml
+++ b/aws/follower_backend_buildspec.yml
@@ -1,0 +1,30 @@
+version: 0.2
+
+env:
+  variables:
+    DOCKER_BUILDKIT: "1"
+    
+phases:
+  pre_build:
+    commands:
+      - $(aws ecr get-login --region $REGION --no-include-email)
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+  build:
+    commands: >-
+      docker build ./backend
+      -t ${ECR_URL}:${IMAGE_TAG}
+      --build-arg XCKAN_BACKEND_SRC=$XCKAN_BACKEND_SRC
+      --build-arg DJANGO_SUPERUSER_USERNAME=$DJANGO_SUPERUSER_USERNAME
+      --build-arg DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD
+      --build-arg DJANGO_SUPERUSER_EMAIL=$DJANGO_SUPERUSER_EMAIL
+  post_build:
+    commands:
+      - docker push ${ECR_URL}:${IMAGE_TAG}
+      - printf '{"ImageURI":"%s"}' ${ECR_URL}:${IMAGE_TAG} > imageDetail.json
+      - envsubst < aws/backend_task.json > taskdef.json
+
+artifacts:
+  files:
+    - imageDetail.json
+    - taskdef.json

--- a/aws/frontend_buildspec.yml
+++ b/aws/frontend_buildspec.yml
@@ -1,0 +1,17 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      nodejs: 16
+  pre_build:
+    commands:
+      - S3_BUCKET_NAME=$(echo $S3_BUCKET_DOMAIN_NAME | cut -f 1 -d. )
+      - cd frontend/app/sip2-ckan
+      - npm install
+  build:
+    commands:
+      - npx nuxt-ts generate --spa
+  post_build:
+    commands:
+      - aws s3 sync --delete --exact-timestamps dist/ s3://${S3_BUCKET_NAME}

--- a/aws/leader_backend_buildspec.yml
+++ b/aws/leader_backend_buildspec.yml
@@ -1,0 +1,30 @@
+version: 0.2
+
+env:
+  variables:
+    DOCKER_BUILDKIT: "1"
+
+phases:
+  pre_build:
+    commands:
+      - chmod +x aws/create_dockerfile.sh && aws/create_dockerfile.sh
+      - $(aws ecr get-login --region $REGION --no-include-email)
+      - AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+  build:
+    commands: >-
+      docker build ./backend
+      -t ${ECR_URL}:leader-${IMAGE_TAG}
+      --build-arg XCKAN_BACKEND_SRC=$XCKAN_BACKEND_SRC
+      --build-arg DJANGO_SUPERUSER_USERNAME=$DJANGO_SUPERUSER_USERNAME
+      --build-arg DJANGO_SUPERUSER_PASSWORD=$DJANGO_SUPERUSER_PASSWORD
+      --build-arg DJANGO_SUPERUSER_EMAIL=$DJANGO_SUPERUSER_EMAIL
+      --build-arg XCKAN_SITEMAP_URL=$XCKAN_SITEMAP_URL
+      --build-arg XCKAN_SITEMAP_DIR=$XCKAN_SITEMAP_DIR
+  post_build:
+    commands:
+      - docker push ${ECR_URL}:leader-${IMAGE_TAG}
+      - printf '[{"name":"django","imageUri":"%s"}]' ${ECR_URL}:leader-${IMAGE_TAG} > imagedefinitions.json
+artifacts:
+  files:
+    - imagedefinitions.json


### PR DESCRIPTION
# What
AWS環境にデプロイに関係したCI/CDファイル一式をawsフォルダ内に作成。

# Why
AWSでの環境でのコミット⇒ビルド⇒デプロイフローを自動化するCI/CDパイプラインの構築に必要なファイルのため。

※アプリに環境変数等の追加が必要になった場合等はエラーとなる可能性有
※2023/01/19 **下記コミットのソース下では正常にCI/CDが稼働することを確認した。**
Commit: [e4bb1a9a9f5db93320529bfa5d660aa2cc16755d](https://github.com/tadokoroshoma/xckan-docker/tree/e4bb1a9a9f5db93320529bfa5d660aa2cc16755d)

*** 

- ファイルの構成は以下の通り

```
➜ ✗ tree -L 2
.
├── Pipfile  
├── README.md
├── aws
│   ├── awscli_setup.sh　　　　　　　　　　# AWSCLIインストールスクリプト(リーダー用)
│   ├── backend_task.json　　　　　　　　　# バックエンドのベースタスク定義ファイル
│   ├── create_dockerfile.sh　　　　　　 　# Dockerfileをビルド時に作成するスクリプト(リーダー用)
│   ├── follower_backend_appspec.yml　　　# フォロワータスクのデプロイ定義ファイル
│   ├── follower_backend_buildspec.yml　　# フォロワータスクのビルド定義ファイル
│   ├── frontend_buildspec.yml　　　　　　# フロントエンドのビルド⇒デプロイ定義ファイル
│   └── leader_backend_buildspec.yml　　　# リーダータスクのビルド定義ファイル
├── backend
│   ├── ....
│   └── xckan_sitelist.json
├── docker-compose.yml
└── frontend
    ├── ...
    └── docs
```